### PR TITLE
DBをmigrate

### DIFF
--- a/backend/app/Category.php
+++ b/backend/app/Category.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    //
+}

--- a/backend/app/Timer.php
+++ b/backend/app/Timer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Timer extends Model
+{
+    //
+}

--- a/backend/database/migrations/2021_08_29_232638_create_categories_table.php
+++ b/backend/database/migrations/2021_08_29_232638_create_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('color');
+            $table->unsignedBigInteger('user_id'); //←見直し
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+}

--- a/backend/database/migrations/2021_08_30_232458_create_timers_table.php
+++ b/backend/database/migrations/2021_08_30_232458_create_timers_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTimersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('timers', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('memo')->nullable();
+            $table->unsignedBigInteger('user_id'); //←見直し
+            $table->timestamp('started_at');
+            $table->timestamp('stopped_at')->default(null)->nullable();
+            $table->timestamps();
+            $table->unsignedBigInteger('category_id')->nullable(); //←見直し
+            $table->string('category_name')->nullable();
+            $table->string('category_color')->nullable();
+
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('category_id')->references('id')->on('categories');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('timers');
+    }
+}


### PR DESCRIPTION
# チケットへのリンク
※migrationがうまくいかず、branchを作り直した
https://bit.ly/3juvLBm

## 変更の概要
* Databaseのmigrationを使ってテーブル、カラムを作成。
* 関連するIssueやプルリクエストは特になし

## なぜこの変更をするのか
* SPAでの開発をすることから、ユーザーデータの入力がデータベース内のテーブルに格納できるようにするため

## やったこと
modelとmigrationファイルを一気に作成（TimerとCategory）
```
php artisan make:model Timer --migration
or
php artisan make:model Timer -m
```

## 変更内容
* UIの変更は無し
* APIの変更もなし
* `database/migrations`のファイルと`/app/`内に`model`を作成

## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## 学習したこと
* Laravelの仕様（DB設計をやり直した）
Laravel5.8からPrimary KeyのdefaultがbigIncrementsになってる
`$table->bigIncrements('id');` と定義すると `users.id` は `bigint(20) unsigned` の型で定義する

bigIncrements（BIGINT）とIncrements（INT）のちがい

[BIGINT]
BIGINT(符号付き)範囲は-9223372036854775808から9223372036854775807。
BIGINT(符号なし)範囲は0から18446744073709551615。

[INT]
INT(符号付き)の範囲は-2147483648〜2147483647。
INT(符号なし)の範囲は0〜4294967295。


* 悩んだこと
migrationがうまくいかない

エラー①：外部キーを設定しているidの型が一致していないことでエラーが起きてる
https://bit.ly/3jtTZM6
```
SQLSTATE[HY000]: General error: 3780 Referencing column 'user_id' and referenced column 'id' in foreign key constraint 'timers_user_id_foreign' are incompatible. (SQL: alter table `timers` add constraint `timers_user_id_foreign` foreign key (`user_id`) references `users` (`id`))
```

エラー②：？→日付の問題で解決した
https://bit.ly/3BszOnP
```
SQLSTATE[HY000]: General error: 1824 Failed to open the referenced table 'categories' (SQL: alter table `timers` add constraint `timers_category_id_foreign` foreign key (`category_id`) references `categories` (`id`))
```
ファイル名が親テーブルより子テーブルのほうが日付があとだと、読み込む順番の問題でエラーが発生するようだが、Users tableとcategories tableの日付に問題はなかった。categories tableとtimers tableの日付が同じことが問題？


他にもこんなエラーが出た
```
SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name
```
```
SQLSTATE[HY000]: General error: 3730 Cannot drop table 'users' referenced by a foreign key constraint 'timers_user_id_foreign' on table 'timers'. (SQL: drop table if exists `users`)
```
→Docker imagesとvolumesを一気に消してリセットした状態からやり直した。



## 今後の変更計画
* なし
DBのテーブルとカラムは一旦close。


## 備考
* **migrationはうまくいったがなぜうまくいったかはよくわかってない。**
→開発がひと段落したら調べる
