### PR TITLE
Vue Routerの設定

### DIFF
--- a/backend/resources/js/router.js
+++ b/backend/resources/js/router.js
@@ -15,19 +15,32 @@ export default new VueRouter({
   routes: [
     {
       path: '/login',
-      component: Login
+      component: Login,
+      beforeEnter(to, from, next) {
+        //処理を追加
+        //遷移しない場合は今開いている画面にとどまる
+      }
     },
     {
       path: '/register',
-      component: Register
+      component: Register,
+      beforeEnter(to, from, next) {
+        //処理を追加
+      }
     },
     {
       path: '/dashboard',
-      component: Dashboard
+      component: Dashboard,
+      beforeEnter(to, from, next) {
+        //処理を追加
+      }
     },
     {
       path: '/timer',
-      component: Timer
+      component: Timer,
+      beforeEnter(to, from, next) {
+        //処理を追加
+      }
     },
     {
       path: '*',

--- a/backend/resources/js/router.js
+++ b/backend/resources/js/router.js
@@ -10,31 +10,28 @@ import store from './store'
 
 Vue.use(VueRouter)
 
-const routes = [
-  {
-    path: '/login',
-    component: Login
-  },
-  {
-    path: '/register',
-    component: Register
-  },
-  {
-    path: '/dashboard',
-    component: Dashboard
-  },
-  {
-    path: '/timer',
-    component: Timer
-  },
-  {
-    path: '*',
-    redirect: '/login'
-  }
-]
-
-const router = new VueRouter({
-  routes
+export default new VueRouter({
+  mode: 'history',
+  routes: [
+    {
+      path: '/login',
+      component: Login
+    },
+    {
+      path: '/register',
+      component: Register
+    },
+    {
+      path: '/dashboard',
+      component: Dashboard
+    },
+    {
+      path: '/timer',
+      component: Timer
+    },
+    {
+      path: '*',
+      redirect: '/login'
+    }
+  ]
 })
-
-export default router

--- a/backend/resources/js/router.js
+++ b/backend/resources/js/router.js
@@ -17,29 +17,44 @@ export default new VueRouter({
       path: '/login',
       component: Login,
       beforeEnter(to, from, next) {
-        //処理を追加
-        //遷移しない場合は今開いている画面にとどまる
+        if (store.getters['auth/check']) {
+          next('/')
+        } else {
+          next()
+        }
       }
     },
     {
       path: '/register',
       component: Register,
       beforeEnter(to, from, next) {
-        //処理を追加
+        if (store.getters['auth/check']) {
+          next('/')
+        } else {
+          next()
+        }
       }
     },
     {
       path: '/dashboard',
       component: Dashboard,
       beforeEnter(to, from, next) {
-        //処理を追加
+        if (store.getters['auth/check']) {
+          next('/login')
+        } else {
+          next()
+        }
       }
     },
     {
-      path: '/timer',
+      path: '/',
       component: Timer,
       beforeEnter(to, from, next) {
-        //処理を追加
+        if (!store.getters['auth/check']) {
+          next('/login')
+        } else {
+          next()
+        }
       }
     },
     {


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
Vue Routerで遷移する画面を設定

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ユーザーの操作で意図しない画面遷移を予防するため

## やったこと
・やったことを簡単にまとめる
ログインした状態ではログインページ、登録ページに行けないようにする
```
​      beforeEnter(to, from, next) {
​        //to, fromを使わなくても入れていないとエラーが出る
​        // auth storeでログインしてるかチェック
​        //ログインしてない場合は今開いている画面にとどまる
​      }
```

現状defaultでhash mode。URL内の#をなくしたいので、historymodeへ変更する


## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
[Vue.js] vue-routerのhashモードとhistoryモードの違いをざっくり理解する
https://bit.ly/3CseXBK

Vue-router チートシート
https://bit.ly/3zm11Hu

ナビゲーションガード
https://bit.ly/39kfF7s

BeforeEnterについて
https://bit.ly/3kpOTkx

## 今後の変更計画
システムエラー用（500）のpath追加してもいいかも。
→初回Deployでは行わない。


## 備考
・その他伝えたいこと