### PR TITLE
新規登録画面のレイアウトを調整

### DIFF
--- a/backend/resources/js/store/error.js
+++ b/backend/resources/js/store/error.js
@@ -9,7 +9,7 @@ const mutations = {
 }
 
 export default {
-  namespaved: true,
+  namespaced: true,
   state,
   mutations
 }

--- a/backend/resources/js/views/Login.vue
+++ b/backend/resources/js/views/Login.vue
@@ -54,8 +54,8 @@
         </v-card-actions>
       </v-card>
     </v-col>
-
     <v-spacer></v-spacer>
+
     <template v-if="loginErrors">
       <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
         <ul v-if="loginErrors.email">

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -6,18 +6,21 @@
     </v-col>
 
     <v-spacer></v-spacer>
-    <v-col>
+    <v-col cols="12" md="5" class="mt-n11">
       <v-card>
         <v-card-title>
-          <h1>登録画面だよ</h1>
+          <h1 class="display-1 font-weight-bold">日本語をペラペラに</h1>
         </v-card-title>
 
         <v-card-text>
-          <div>登録してね</div>
+          <div class="text--primary subtitle-2">
+            日本語学習を仕組み化してペラペラになるには練習が必要です。
+            <br />学習内容を記録して練習プロセスを見える化してみましょう。
+          </div>
         </v-card-text>
 
-        <v-card-title>
-          <h2>アカウントを作る</h2>
+        <v-card-title class="pb-0">
+          <h2 class="title">アカウントを作る</h2>
         </v-card-title>
 
         <v-card-text>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -25,8 +25,13 @@
 
         <v-card-text>
           <v-form>
-            <v-text-field tabindex="1" label="ユーザー名" prepend-icon="mdi-account-circle" />
-            <v-text-field tabindex="2" label="メールアドレス" prepend-icon="mdi-email" />
+            <v-text-field
+              tabindex="1"
+              label="ユーザー名"
+              v-model="registerForm.name"
+              prepend-icon="mdi-account-circle"
+            />
+            <v-text-field tabindex="2" label="メールアドレス" v-model="registerForm.email" prepend-icon="mdi-email" />
             <v-text-field
               tabindex="3"
               label="パスワード"
@@ -34,7 +39,6 @@
               :type="showPassword ? 'text' : 'password'"
               :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
               @click:append="showPassword = !showPassword"
-              @keyup.enter="register"
             />
             <v-text-field
               tabindex="4"
@@ -47,15 +51,8 @@
             />
 
             <small>
-              アカウントを作成することにより、
-              <v-dialog>
-                利用規約
-              </v-dialog>
-              および
-              <v-dialog>
-                プライバシーポリシー
-              </v-dialog>
-              に同意したものとみなされます。
+              アカウントを作成することにより、 利用規約 および プライバシーポリシー に同意したものとみなされます。
+              <!-- TODO: v-dialogを追加 -->
             </small>
           </v-form>
         </v-card-text>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -94,7 +94,46 @@
 </template>
 
 <script>
-export default {}
+export default {
+  data() {
+    return {
+      snackbar: false,
+      showPassword: false,
+      registerForm: {
+        name: '',
+        email: '',
+        password: '',
+        password_confirmation: ''
+      },
+      termsDialog: false,
+      privacyDialog: false
+    }
+  },
+  created() {
+    this.clearError()
+  },
+  methods: {
+    async register() {
+      await this.$store.dispatch('auth/regsiter', this.registerForm)
+
+      if (this.apiStatus) {
+        this.$router.push('/')
+      }
+    },
+    clearError() {
+      this.$store.commit('auth/SET_REGISTER_ERROR_MESSAGES', null)
+    }
+  },
+  computed: {
+    apiStatus() {
+      return this.$store.state.auth.apiStatus
+    },
+    registerErrors() {
+      this.snackbar = true
+      return this.$store.state.auth.registerErrorMessages
+    }
+  }
+}
 </script>
 
 <style></style>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -1,12 +1,12 @@
 <template>
   <v-row>
     <v-spacer></v-spacer>
-    <v-col>
+    <v-col cols="9" md="6" class="mt-n11">
       <!-- <v-img>TODO: 画像を追加する</v-img> -->
     </v-col>
-
     <v-spacer></v-spacer>
-    <v-col cols="12" md="5" class="mt-n11">
+
+    <v-col cols="12" md="5">
       <v-card>
         <v-card-title>
           <h1 class="display-1 font-weight-bold">日本語をペラペラに</h1>
@@ -74,6 +74,7 @@
         </v-btn>
       </v-card>
     </v-col>
+    <v-spacer></v-spacer>
 
     <template v-if="registerErrors">
       <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -58,11 +58,38 @@
         </v-card-text>
 
         <v-spacer></v-spacer>
-        <v-btn tabindex="5" color="success" text @click="register">
+        <v-btn
+          tabindex="5"
+          :disabled="
+            registerForm.name === '' ||
+              registerForm.email === '' ||
+              registerForm.password === '' ||
+              registerForm.password_confirmation === ''
+          "
+          color="success"
+          text
+          @click="register"
+        >
           登録
         </v-btn>
       </v-card>
     </v-col>
+
+    <template v-if="registerErrors">
+      <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
+        <ul v-if="registerErrors.email">
+          <li v-for="msg in registerErrors.email" :key="msg">
+            <span>{{ msg }}</span>
+          </li>
+        </ul>
+        <ul v-if="registerErrors.password">
+          <li v-for="msg in registerErrors.password" :key="msg">
+            <span>{{ msg }}</span>
+          </li>
+        </ul>
+        <v-btn text dark @click="snackbar = false">閉じる</v-btn>
+      </v-snackbar>
+    </template>
   </v-row>
 </template>
 


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3tTHpcs

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
新規登録画面のレイアウトを調整 \
バランスを整えた

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
RichなUIにするため

## やったこと
・やったことを簡単にまとめる
v-spacerを使ってスペースを調整
入力内容をstoreで判定するロジックを追加

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

## 今後の変更計画
色を追加していく（一番最後）


## 備考
・その他伝えたいこと