### PR TITLE
会員登録APIの実装

### DIFF
--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -9,6 +9,8 @@ use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
+use Illuminate\Http\Request;
+
 class RegisterController extends Controller
 {
     /*
@@ -69,5 +71,10 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    protected function registered(Request $request, $user)
+    {
+        return $user;
     }
 }

--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -76,5 +76,6 @@ class RegisterController extends Controller
     protected function registered(Request $request, $user)
     {
         return $user;
+        throw new \Exception('予期せぬエラー');
     }
 }

--- a/backend/app/Providers/RouteServiceProvider.php
+++ b/backend/app/Providers/RouteServiceProvider.php
@@ -73,7 +73,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function mapApiRoutes()
     {
         Route::prefix('api')
-             ->middleware('api')
+             ->middleware('web')
              ->namespace($this->namespace)
              ->group(base_path('routes/api.php'));
     }

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -34,6 +34,7 @@ return [
     */
 
     'connections' => [
+    // ※MySQLを使用
 
         'sqlite' => [
             'driver' => 'sqlite',
@@ -61,6 +62,12 @@ return [
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
+        ],
+
+        'mysql_testing' => [
+            'driver' => 'mysql',
+            'database' => ':memory:',
+            'prefix' => '',
         ],
 
         'pgsql' => [

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </filter>
     <php>
         <server name="APP_ENV" value="testing"/>
+        <env name="DB_CONNECTION" value="mysql_testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
         <server name="DB_CONNECTION" value="sqlite"/>

--- a/backend/tests/Feature/RegisterApiTest.php
+++ b/backend/tests/Feature/RegisterApiTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class RegisterApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A basic feature test example.
+     *
+     * @test
+     */
+
+     public function should_createAndReturnNewUser()
+     {
+         $data = [
+             'name' => 'Recordable User',
+             'email' => 'dummy@dummy.com',
+             'password' => 'dummydegozaru',
+             'password_confirmation' => 'dummydegozaru',
+         ];
+
+         $response = $this->json('POST', route('register'), $data);
+
+         $user = User::first();
+         $this->assertEquals($data['name'], $user->name);
+
+         $response
+            ->assertStatus(201)
+            ->assertJson(['name' => $user->name]);
+     }
+
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
会員登録APIの実装

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ユーザーが会員登録をできるようにするため。

## やったこと
・やったことを簡単にまとめる
「RouterServiceProvider.phpを変更」
`RouteServiceProvider` はアプリケーションの起動時にルート定義を読み込むためのクラス。`routes/api.php` に記述したルート定義に適用されるミドルウェアグループは `api` だが、今回はそれを `web` に変更。

今回実装する API は内部からしか呼ばれない上にクッキー認証を行う。外部APIは使っていないのでmidlewareを `web` に設定している。

**「darabase.phpにテストの接続情報を追加」**
ImmemoryのMySQLを利用。
テスト実行が終わると使ったデータを削除するように設定。

**「phpunit.xmlにDB接続設定を追加」**
テストでDBに接続するので、接続設定を追加した。

**「会員登録のテストコードを追加」**
```
php artisan make:test RegisterApiTest
```
`test/Feature/RegisterApiTest.php`

Request： name, email, password, password_confirmation
Response：定義しているページへredirect。ここはFront-Endで操作

**「RegisterControllerにhttp requestを追加」**
参照
backend/vendor/laravel/framework/src/Illuminate/Foundation/Auth/RegistersUsers.php

**「予期せぬエラーを追加」**
予期せぬエラーで悩むことを減らすため。

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

```
[app bash]
./vendor/bin/phpunit --testdox
```

良きせぬエラーのコードはこれを参考に追加。
https://bit.ly/3A8vfhC


## 今後の変更計画
なし

## 備考
・その他伝えたいこと