### PR TITLE
ログインAPI（内部API）の実装

### DIFF
--- a/backend/app/Http/Controllers/Auth/LoginController.php
+++ b/backend/app/Http/Controllers/Auth/LoginController.php
@@ -37,4 +37,9 @@ class LoginController extends Controller
     {
         $this->middleware('guest')->except('logout');
     }
+
+    protected function authenticated(Request $request, $user)
+    {
+        return $user;
+    }
 }

--- a/backend/app/Http/Controllers/Auth/LoginController.php
+++ b/backend/app/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
+use Illuminate\Http\Request;
+
 class LoginController extends Controller
 {
     /*
@@ -41,5 +43,6 @@ class LoginController extends Controller
     protected function authenticated(Request $request, $user)
     {
         return $user;
+        throw new \Exception('予期せぬエラー');
     }
 }

--- a/backend/tests/Feature/LoginApiTest.php
+++ b/backend/tests/Feature/LoginApiTest.php
@@ -11,13 +11,16 @@ class LoginApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function setUp(): void //エラーになる？
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->user = factory(User::class)->create();
     }
 
+     /**
+     * @test
+     */
     public function should_returnRegisterdNewUser()
     {
         $response = $this->json('POST', route('login'), [

--- a/backend/tests/Feature/LoginApiTest.php
+++ b/backend/tests/Feature/LoginApiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LoginApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void //エラーになる？
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+    }
+
+    public function should_returnRegisterdNewUser()
+    {
+        $response = $this->json('POST', route('login'), [
+            'email' => $this->user->email,
+            'password' => 'password',
+        ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJson(['name' => $this->user->name]);
+
+        $this->assertAuthenticatedAs($this->user);
+    }
+
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
```
php artisan make:test LoginApiTest
```

「ログインテストコードの追加」

「LoginControllerへユーザーを返す処理を追加」

「`@test`コメントを追加」
注釈がないとエラーが出る

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ユーザーがログインしてサービスを使えるようにするため

## やったこと
・やったことを簡単にまとめる
会員登録同様、デフォルトの挙動では認証成功後には定義されたページにリダイレクトするレスポンスを返すが、今回は登録ユーザーの情報を返却させている

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
phpunitテストをするとき、注釈がテストコードに関わることを意味する。
```
     /**
     * @test
     */
```
これがないとwarning出る
`No tests found in class "Tests\Feature\LoginApiTest".`

## 今後の変更計画

## 備考
・その他伝えたいこと