### PR TITLE
LogoutAPIの追加

### DIFF
--- a/backend/app/Http/Controllers/Auth/LoginController.php
+++ b/backend/app/Http/Controllers/Auth/LoginController.php
@@ -45,4 +45,10 @@ class LoginController extends Controller
         return $user;
         throw new \Exception('予期せぬエラー');
     }
+
+    protected function loggedOut(Request $request)
+    {
+        $request->session()->regenerate();
+        return response()->json();
+    }
 }

--- a/backend/tests/Feature/LogoutApiTest.php
+++ b/backend/tests/Feature/LogoutApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\User;
+
+class LogoutApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function should_LogoutRegisterdUser()
+    {
+        $response = $this->actingAs($this->user)
+                         ->json('POST', route('logout'));
+
+        $response->assertStatus(200);
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3A7sjkZ

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
ログアウトAPIの追加

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ユーザーがログイン後にログアウトするため。

## やったこと
・やったことを簡単にまとめる
```
php artisan make:test LogoutApiTest
```

インプットは何もないので、ログアウト処理が成功したら、status200をresponseとして返した。


## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

## 今後の変更計画


## 備考
・その他伝えたいこと