### PR TITLE
エラーの解決のため、branchをそのままで実施。

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,3 +74,15 @@ jobs:
             -f infra/docker/nginx/Dockerfile \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+      - name: Push php image to ecr
+        env:
+          DOCKER_BUILDKIT: 1
+          ECR_REGISTRY: ${{ steps.amazon-ecr-login.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.SYSTEM_NAME }}-${{ env.ENV_NAME }}-${{ env.SERVICE_NAME }}-php
+        run: |
+          docker build \
+            --cache-from=$ECR_REGISTRY/$ECR_REPOSITORY:latest --build-arg BUILDKIT_INLINE_CACHE=1 . \
+            -f infra/docker/nginx/Dockerfile \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/infra/docker/nginx/Dockerfile
+++ b/infra/docker/nginx/Dockerfile
@@ -16,5 +16,7 @@ COPY --from=node /usr/local/lib /usr/local/lib
 COPY --from=node /opt /opt
 # nginx config file
 COPY ./infra/docker/nginx/*.conf /etc/nginx/conf.d/
+# need to nginx image
+COPY ./backend/public /work/backend/public
 
 WORKDIR /work/backend

--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -28,4 +28,7 @@ RUN apt-get update && \
 COPY ./infra/docker/php/php-fpm.d/zzz-www.conf /usr/local/etc/php-fpm.d/zzz-www.conf
 COPY ./infra/docker/php/php.ini /usr/local/etc/php/php.ini
 
+# ready to deploy
+COPY --chown=www-data: ./backend /work/backend
+
 WORKDIR /work/backend


### PR DESCRIPTION
問題のエラー

```
[webpack-cli] Error: Unknown option '--no-progress'
[webpack-cli] Run 'webpack --help' to see available commands and options
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @ production: `cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the @ production script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-03T06_16_41_034Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @ prod: `npm run production`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the @ prod script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-03T06_16_41_061Z-debug.log
Error: Process completed with exit code 2.
```
エラーの解決のため、branchをそのままで実施。

ざっくりと理解すると、deployするための処理がうまく走ってない。
phpとnginx imageをECRへpushする処理をそれぞれ追加する。



`.dockerignore`

今回はリポジトリ全体が Docker デーモンに送信される。その中でも node_modules ディレク トリは、サイズが巨大な割にイメージへのコピー対象ということでもない。このようなディレクトリをあらかじめ Docker デーモンへの送信対象外と指定することで、docker build の高速化が見込めます。

送信対象外とするには、.dockerignore で指定

**Docker Daemonとは**
Docker Engineの1つ。
**Docker Engine**
・Docker CLI(Command Line Interface)：`docker compose up -d`などをするためのCLI
・Docker Engine API：Docker CLIによって呼ばれるAPI
・Docker Daemon：Dockerの**background Process**として動くProgramのこと

DockerはProcessをisolateして簡単に素早く環境を作って開発、移動、実行できるPlatform、コンテナ技術
全ての依存関係をPackage化して、コンテナとして動かす。
仮想環境ではない。


※Daemonの語源：守護神（悪魔というイメージが強いが、このイメージは無くしておく）
daemon（守護神）とはギリシャ神話に登場し、神々が煩わされたくないと考えた雑事を処理した存在。
同様に**コンピュータのデーモンもユーザーが煩わされたくないタスクをバックグラウンドで実行**している。
> 実は気まぐれにDaemonと呼ぶようになったらしい。 cf. Maxwell's demon

`/php/Dockerfile`
--chown オプションを付けて、/work/backend ディレ クトリのオーナーとグループが root ではなく www-data になるようにする

Laravel が動いているとき、backend ディレクトリ配 下の storage ディレクトリや bootstrap/cache ディレクトリ内にファイルが書き込まれることがあるが、その書き込み処理が権限エラーとならないようにするため








