### PR TITLE
snackbarをcomponentで切り出す

### DIFF
--- a/backend/resources/js/App.vue
+++ b/backend/resources/js/App.vue
@@ -1,9 +1,5 @@
 <template>
   <v-app>
-    <v-snackbar top v-model="systemErrorSnackbar" color="error">
-      A system error has occurred.
-      <v-btn text @click="systemErrorSnackbar = false">CLOSE</v-btn>
-    </v-snackbar>
     <NavBar />
     <NavDrawer />
     <v-main>
@@ -12,6 +8,7 @@
       </v-container>
     </v-main>
     <MobileNav />
+    <SystemError />
   </v-app>
 </template>
 
@@ -19,6 +16,7 @@
 import NavBar from './components/NavBar.vue'
 import NavDrawer from './components/NavDrawer.vue'
 import MobileNav  from './components/MobileNav.vue'
+import SystemError from './components/snackbar/SystemError.vue'
 
 import { INTERNAL_SERVER_ERROR } from './plugin/status'
 
@@ -26,12 +24,8 @@ export default {
   components: {
     NavBar,
     NavDrawer,
-    MobileNav
-  },
-  data() {
-    return {
-      systemErrorSnackbar: false
-    }
+    MobileNav,
+    SystemError
   },
   computed: {
     errorCode() {
@@ -42,11 +36,11 @@ export default {
     errorCode: {
       handler(val) {
         if (val === INTERNAL_SERVER_ERROR) {
-          this.systemErrorSnackbar = true
+          this.snackbarSystemError = true
           this.$router.push('/500')
         }
       },
-      //createdで呼び出し
+      //beforeCreatedとcreatedの間で呼び出す
       immediate: true
     },
     //同じrouteの異なるパラメータで画面遷移しても、vue-routerは画面を再描画しないのでwatchで監視する

--- a/backend/resources/js/components/snackbar/DashboardError.vue
+++ b/backend/resources/js/components/snackbar/DashboardError.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-snackbar top v-model="snackbar.error" color="error">
+      An error has occurred. message：{{ errorMessage }}
+      <v-btn text @click="snackbar.error = false">CLOSE</v-btn>
+  </v-snackbar>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      snackbar: {
+        error: false
+      },
+      errorMessage: ""
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/backend/resources/js/components/snackbar/LoginErrors.vue
+++ b/backend/resources/js/components/snackbar/LoginErrors.vue
@@ -1,0 +1,39 @@
+<template>
+  <div v-if="loginErrors">
+    <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
+      <ul v-if="loginErrors.email">
+        <li v-for="msg in loginErrors.email" :key="msg">
+          <span>{{ msg }}</span>
+        </li>
+      </ul>
+      <ul v-if="loginErrors.password">
+        <li v-for="msg in loginErrors.password" :key="msg">
+          <span>{{ msg }}</span>
+        </li>
+      </ul>
+      <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
+    </v-snackbar>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      snackbar: false
+    }
+  },
+  computed: {
+    loginErrors() {
+      this.snackbar = true
+      return this.$store.state.auth.loginErrorMessages
+    }
+  }
+}
+</script>
+
+<style scoped>
+ul {
+  list-style: none;
+}
+</style>

--- a/backend/resources/js/components/snackbar/LoginErrors.vue
+++ b/backend/resources/js/components/snackbar/LoginErrors.vue
@@ -1,6 +1,7 @@
 <template>
   <div v-if="loginErrors">
     <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
+      <!-- TODO: email, password毎に表示するメッセージを変更する 【時期update】-->
       <ul v-if="loginErrors.email">
         <li v-for="msg in loginErrors.email" :key="msg">
           <span>{{ msg }}</span>

--- a/backend/resources/js/components/snackbar/RegisterErrors.vue
+++ b/backend/resources/js/components/snackbar/RegisterErrors.vue
@@ -1,0 +1,39 @@
+<template>
+  <div v-if="registerErrors">
+    <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
+      <ul v-if="registerErrors.email">
+        <li v-for="msg in registerErrors.email" :key="msg">
+          <span>{{ msg }}</span>
+        </li>
+      </ul>
+      <ul v-if="registerErrors.password">
+        <li v-for="msg in registerErrors.password" :key="msg">
+          <span>{{ msg }}</span>
+        </li>
+      </ul>
+      <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
+    </v-snackbar>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      snackbar: false
+    }
+  },
+  computed: {
+    registerErrors() {
+      this.snackbar = true
+      return this.$store.state.auth.registerErrorMessages
+    }
+  }
+}
+</script>
+
+<style scoped>
+ul {
+  list-style: none;
+}
+</style>

--- a/backend/resources/js/components/snackbar/SystemError.vue
+++ b/backend/resources/js/components/snackbar/SystemError.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-snackbar top v-model="snackbarSystemError" color="error">
+    A system error has occurred.
+    <v-btn text @click="snackbarSystemError = false">CLOSE</v-btn>
+  </v-snackbar>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      snackbarSystemError: false
+    }
+  }
+}
+</script>
+
+<style>
+</style>

--- a/backend/resources/js/views/Dashboard.vue
+++ b/backend/resources/js/views/Dashboard.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <v-snackbar top v-model="snackbar.error" color="error">
+    <!-- <v-snackbar top v-model="snackbar.error" color="error">
       An error has occurred. message：{{ errorMessage }}
       <v-btn text @click="snackbar.error = false">CLOSE</v-btn>
-    </v-snackbar>
-
+    </v-snackbar> -->
+    <DashboardError />
     <span class="title">
       <v-icon class="mr-2 mb-1" color="#02E3FF">mdi-archive-clock</v-icon>My Record
     </span>
@@ -158,10 +158,12 @@
 <script>
 import ICountUp from "vue-countup-v2"
 import moment from "moment"
+import DashboardError from '../components/snackbar/DashboardError.vue'
 
 export default {
   components: {
-    ICountUp
+    ICountUp,
+    DashboardError
   },
   data() {
     return {

--- a/backend/resources/js/views/Dashboard.vue
+++ b/backend/resources/js/views/Dashboard.vue
@@ -158,7 +158,7 @@
 <script>
 import ICountUp from "vue-countup-v2"
 import moment from "moment"
-import DashboardError from '../components/snackbar/DashboardError.vue'
+import DashboardError from "../components/snackbar/DashboardError.vue"
 
 export default {
   components: {

--- a/backend/resources/js/views/Login.vue
+++ b/backend/resources/js/views/Login.vue
@@ -6,7 +6,7 @@
     </v-col>
     <v-col cols="12" md="5">
       <!-- <v-card elevation="0" style="background-color: var(--v-background-base)"> -->
-        <!-- TODO:次回リリース時に対応↑ -->
+        <!-- TODO:次回リリース時に対応（検討中）-->
       <v-card>
         <v-card-title>
           <h1 class="display-1 font-weight-bold">Visualize the learning process.</h1>
@@ -76,7 +76,9 @@
       </v-card>
     </v-col>
     <v-spacer></v-spacer>
-    <LoginErrors />
+
+    <login-errors/>
+
   </v-row>
 </template>
 

--- a/backend/resources/js/views/Login.vue
+++ b/backend/resources/js/views/Login.vue
@@ -75,26 +75,8 @@
         </v-card-actions>
       </v-card>
     </v-col>
-
     <v-spacer></v-spacer>
-
-    <!-- <template v-if="loginErrors">
-      <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
-        <ul v-if="loginErrors.email">
-          <li v-for="msg in loginErrors.email" :key="msg">
-            <span>{{ msg }}</span>
-          </li>
-        </ul>
-        <ul v-if="loginErrors.password">
-          <li v-for="msg in loginErrors.password" :key="msg">
-            <span>{{ msg }}</span>
-          </li>
-        </ul>
-        <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
-      </v-snackbar>
-    </template> -->
     <LoginErrors />
-
   </v-row>
 </template>
 
@@ -107,7 +89,6 @@ export default {
   },
   data() {
     return {
-      // snackbar: false,
       showPassword: false,
       loginForm: {
         email: '',

--- a/backend/resources/js/views/Login.vue
+++ b/backend/resources/js/views/Login.vue
@@ -77,7 +77,8 @@
     </v-col>
 
     <v-spacer></v-spacer>
-    <template v-if="loginErrors">
+
+    <!-- <template v-if="loginErrors">
       <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
         <ul v-if="loginErrors.email">
           <li v-for="msg in loginErrors.email" :key="msg">
@@ -91,15 +92,22 @@
         </ul>
         <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
       </v-snackbar>
-    </template>
+    </template> -->
+    <LoginErrors />
+
   </v-row>
 </template>
 
 <script>
+import LoginErrors from "../components/snackbar/LoginErrors.vue"
+
 export default {
+  components: {
+    LoginErrors
+  },
   data() {
     return {
-      snackbar: false,
+      // snackbar: false,
       showPassword: false,
       loginForm: {
         email: '',
@@ -135,17 +143,14 @@ export default {
   computed: {
     apiStatus() {
       return this.$store.state.auth.apiStatus
-    },
-    loginErrors() {
-      this.snackbar = true
-      return this.$store.state.auth.loginErrorMessages
     }
+    // loginErrors() {
+    //   this.snackbar = true
+    //   return this.$store.state.auth.loginErrorMessages
+    // }
   }
 }
 </script>
 
-<style scoped>
-ul {
-  list-style: none;
-}
+<style>
 </style>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -84,22 +84,6 @@
       </v-card>
     </v-col>
     <v-spacer></v-spacer>
-
-    <!-- <template v-if="registerErrors">
-      <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
-        <ul v-if="registerErrors.email">
-          <li v-for="msg in registerErrors.email" :key="msg">
-            <span>{{ msg }}</span>
-          </li>
-        </ul>
-        <ul v-if="registerErrors.password">
-          <li v-for="msg in registerErrors.password" :key="msg">
-            <span>{{ msg }}</span>
-          </li>
-        </ul>
-        <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
-      </v-snackbar>
-    </template> -->
     <resgister-errors />
 
   </v-row>
@@ -114,7 +98,6 @@ export default {
   },
   data() {
     return {
-      // snackbar: false,
       showPassword: false,
       registerForm: {
         name: '',
@@ -153,10 +136,6 @@ export default {
     apiStatus() {
       return this.$store.state.auth.apiStatus
     }
-    // registerErrors() {
-    //   this.snackbar = true
-    //   return this.$store.state.auth.registerErrorMessages
-    // }
   }
 }
 </script>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -84,7 +84,8 @@
       </v-card>
     </v-col>
     <v-spacer></v-spacer>
-    <template v-if="registerErrors">
+
+    <!-- <template v-if="registerErrors">
       <v-snackbar v-model="snackbar" multi-line vertical color="error" right bottom>
         <ul v-if="registerErrors.email">
           <li v-for="msg in registerErrors.email" :key="msg">
@@ -98,15 +99,22 @@
         </ul>
         <v-btn text dark @click="snackbar = false">CLOSE</v-btn>
       </v-snackbar>
-    </template>
+    </template> -->
+    <resgister-errors />
+
   </v-row>
 </template>
 
 <script>
+import ResgisterErrors from '../components/snackbar/RegisterErrors.vue'
+
 export default {
+  components: {
+    ResgisterErrors
+  },
   data() {
     return {
-      snackbar: false,
+      // snackbar: false,
       showPassword: false,
       registerForm: {
         name: '',
@@ -144,11 +152,11 @@ export default {
   computed: {
     apiStatus() {
       return this.$store.state.auth.apiStatus
-    },
-    registerErrors() {
-      this.snackbar = true
-      return this.$store.state.auth.registerErrorMessages
     }
+    // registerErrors() {
+    //   this.snackbar = true
+    //   return this.$store.state.auth.registerErrorMessages
+    // }
   }
 }
 </script>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -141,8 +141,5 @@ export default {
 }
 </script>
 
-<style scoped>
-ul {
-  list-style: none;
-}
+<style>
 </style>

--- a/backend/resources/js/views/Register.vue
+++ b/backend/resources/js/views/Register.vue
@@ -84,6 +84,7 @@
       </v-card>
     </v-col>
     <v-spacer></v-spacer>
+
     <resgister-errors />
 
   </v-row>

--- a/backend/resources/js/views/Timer.vue
+++ b/backend/resources/js/views/Timer.vue
@@ -2,8 +2,9 @@
   <div class="body" v-resize="onResize">
     <!-- TODO: snackbarをcomponentとして切り出す（リリース後のアップデート時に実施）-->
     <div v-if="!isEmpty(timers)">
+
       <v-snackbar
-        v-model="snackbar.activeTimer"
+        v-model="snackbar.timerActive"
         :multi-line="true"
         top
         right
@@ -11,11 +12,12 @@
         :color="counter.timer.category_color"
       >
       <strong class="timer-name pr-4">{{ counter.timer.name }}</strong>
-      {{ activeTimerString }}
+      {{ timerActiveString }}
         <v-btn text @click="stopTimer()">
           <v-icon x-large>mdi-stop</v-icon>
         </v-btn>
       </v-snackbar>
+
     </div>
 
     <v-snackbar top v-model="snackbar.done" color="#02E3FF" :multi-line="true">
@@ -127,7 +129,7 @@
                 </template>
 
               <template v-slot:item.time="{ item }">
-                <span v-if="showTimer(item)">{{ activeTimerString }}</span>
+                <span v-if="showTimer(item)">{{ timerActiveString }}</span>
                 <span v-else>{{ calculateTimeSpent(item) }}</span>
               </template>
             </v-data-table>
@@ -712,7 +714,7 @@ export default {
   data() {
     return {
       snackbar: {
-        activeTimer: false,
+        timerActive: false,
         done: false,
         updated: false,
         deleted: false,
@@ -809,7 +811,7 @@ export default {
       page: 1,
       fab: false, //floatingActionBtn（名前変えるかも）
       counter: { seconds: 0, timer: { name: '', category: '' } },
-      activeTimerString: "Calculating...",
+      timerActiveString: "Calculating...",
       newTimerValid: false,
       errorMessage: "",
       mask: '!#XXXXXXXX', //カラーコードの入力制御
@@ -920,24 +922,24 @@ export default {
       );
       this.counter.ticker = setInterval(() => {
         const time = this._readableTimeFromSeconds(++this.counter.seconds)
-        this.activeTimerString = `${time.hours}:${time.minutes}:${time.seconds}`
+        this.timerActiveString = `${time.hours}:${time.minutes}:${time.seconds}`
       }, 1000)
-      this.snackbar.activeTimer = true
+      this.snackbar.timerActive = true
     },
     stopTimer: function() {
       window.axios
         .post(`/api/timers/stop`)
         .then(response => {
-          const activeTimer = this.timers.find(
+          const timerActive = this.timers.find(
             timer => timer.id === this.counter.timer.id
           )
-          // activeTimerをストップ
-          activeTimer.stopped_at = response.data.stopped_at
+          // timerActiveをストップ
+          timerActive.stopped_at = response.data.stopped_at
           // tickerをストップする
           clearInterval(this.counter.ticker)
           this.counter = { seconds: 0, timer: { name: "", category: "" } }
-          this.activeTimerString = "Calculating..."
-          this.snackbar.activeTimer = false;
+          this.timerActiveString = "Calculating..."
+          this.snackbar.timerActive = false;
           this.snackbar.done = true
 
           // confetti

--- a/backend/resources/js/views/Timer.vue
+++ b/backend/resources/js/views/Timer.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="body" v-resize="onResize">
-    <!-- TODO: snackbarをcomponentとして切り出す（リリース後のアップデート時に実施）-->
+    <!-- TODO: timerActiveのSnackbarをcomponentとして切り出したい（リリース後のアップデート時に実施）-->
     <div v-if="!isEmpty(timers)">
-
       <v-snackbar
         v-model="snackbar.timerActive"
         :multi-line="true"
@@ -17,9 +16,9 @@
           <v-icon x-large>mdi-stop</v-icon>
         </v-btn>
       </v-snackbar>
-
     </div>
 
+    <!-- TODO: snackbarをcomponentとして切り出す（リリース後のアップデート時に実施）-->
     <v-snackbar top v-model="snackbar.done" color="#02E3FF" :multi-line="true">
       Good Job! You've learned a good deal today. Let's Try to beat your personal best again tomorow!
     </v-snackbar>

--- a/infra/terraform/readme.md
+++ b/infra/terraform/readme.md
@@ -1,5 +1,8 @@
-# terraform v1.0.5
+# terraform
+
 ## 別で Directory を作成する
+
+※ 次回以降のアップデート時に使用予定
 
 容量がかなり肥大化してしまうことが見込めるので下記 Repository で作業をする \
 https://github.com/soregashi-27/recordable-infra


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
snackbarをcomponentで切り出す（Timer.vue以外）

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
コードの可読性を上げるため

## やったこと
・やったことを簡単にまとめる
snackbar dirを作成、Error系のsnackbarをまとめて切り出し

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

## 今後の変更計画
Timer.vueのsnackbarも切り出す
Web viewとlogicを分ける書き方に随時変更していく

## 備考
・その他伝えたいこと