### PR TITLE
fastcgi_passの書き換え

### DIFF
--- a/infra/docker/nginx/default.conf
+++ b/infra/docker/nginx/default.conf
@@ -23,7 +23,7 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
+        fastcgi_pass app:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
fastcgi_passの書き換え

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ECSのタスク定義がしたくてコンテナを定義していたら、作成ができなかった。
Webコンテナのネットワーク設定に問題がありそうなので記述を変更。

## やったこと
・やったことを簡単にまとめる
元々はこう書いてたのを
```
fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
```

こう書き直した
```
fastcgi_pass app:9000;
```


## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

nginxの`default.conf`記述のベースはこれ
https://readouble.com/laravel/6.x/ja/deployment.html#nginx
UnixドメインソケットからTCPソケットへ書き直した。

なぜかUnixドメインソケットだとECSのタスク定義に失敗する。
ソケット：プロセス（プログラムの実行単位）間のデータやり取り方法の1つ
・Unixドメインソケット：実行されるプロセス間のデータ通信の終点に使われるインターフェース
・TCPソケット：サーバとクライアントの2者間で通信を行うためのインターファース、という理解...。

※このあたりまだよくわかってない....。
http://slides.com/ryoutsunomiya/php-socket-programming
http://research.nii.ac.jp/~ichiro/syspro98/socket.html
参考：nginxとphp-fpmの通信はどうなってんの？
https://bit.ly/30GUVG3


```
fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
```
nginxでDeployする時のdefault設定。

```
fastcgi_pass app:9000;
```
php-fpmをappコンテナで起動するので`app:`。`9000`はphp-fpmが起動するdefaultのポート番号らしい


php-fpmとはphp標準のアプリケーションサーバー。（FastCGI Process Managerの略。）
Fast CGIとは、Webサーバー上でプログラムを動かすための仕組みである、CGI（Common Gataway Interface）を改良したもの。
一度起動させたプログラムを待機させることで**プログラムの起動や終了の処理を軽減**出来たりする。
phpにはモジュール版とCGI（php-fpm）版があるが、今回は省略。別の機会でまとめる。（早くデプロイしたい。）

参考：Php-fpmについて
https://qiita.com/wjtnk/items/fa2b9d848bc64261d0e9


## 今後の変更計画

## 備考
・その他伝えたいこと
本番環境にDeployする場合、必ず下記コマンドを実行する
```
php artisan config:cache
```
