### PR TITLE
unixドメインソケットに戻す

### DIFF
--- a/infra/docker/nginx/default.conf
+++ b/infra/docker/nginx/default.conf
@@ -23,7 +23,7 @@ server {
     error_page 404 /index.php;
 
     location ~ \.php$ {
-        fastcgi_pass app:9000;
+        fastcgi_pass unix:/var/run/php-fpm/php-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
Deploy時EC2を使うことを検討して書き換えようとしたが、本来のunixドメインソケットへ戻した。

以下省略。