### PR TITLE
http通信をするための設定を追加

### DIFF
--- a/backend/app/Http/Middleware/TrustProxies.php
+++ b/backend/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies;
+    protected $proxies = "*";
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
http通信を行うために、`backend/app/Http/Middleware/TrustProxies.php`に設定を追加した。
```
    protected $proxies = "*";
```

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
Deployしようとしたときに、`502 bad gateway`のエラーや`503`のエラー（今は解決済み）が発生したから。

## やったこと
・やったことを簡単にまとめる
http通信を行うために、`backend/app/Http/Middleware/TrustProxies.php`に設定を追加した。
```
    protected $proxies = "*";
```


## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
AWSのApplication Load BalancerはIPアドレスが決まっていないため、http通信を設定する場合は`"*"`と設定するらしい

## 今後の変更計画


## 備考
・その他伝えたいこと