### PR TITLE
Nginxのログを設定

### DIFF
--- a/infra/docker/nginx/Dockerfile
+++ b/infra/docker/nginx/Dockerfile
@@ -16,6 +16,7 @@ COPY --from=node /usr/local/lib /usr/local/lib
 COPY --from=node /opt /opt
 # nginx config file will be output to /etc/nginx/conf.d/ by envsubst
 COPY ./infra/docker/nginx/default.conf /etc/nginx/templates/default.conf.template
+COPY ./infra/docker/nginx/nginx.conf /etc/nginx/nginx.conf
 # need to nginx image
 COPY ./backend/public /work/backend/public
 

--- a/infra/docker/nginx/default.conf
+++ b/infra/docker/nginx/default.conf
@@ -21,8 +21,11 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
     }
 
-    location = /favicon.ico { access_log off; log_not_found off; }
-    location = /robots.txt  { access_log off; log_not_found off; }
+    location ~ \.(css|gif|ico|jpeg|jpg|js|pdf|png|svg|txt|zip) {
+        expires 30d;
+        access_log off;
+        log_not_found off;
+    }
 
     error_page 404 /index.php;
 

--- a/infra/docker/nginx/nginx.conf
+++ b/infra/docker/nginx/nginx.conf
@@ -1,0 +1,39 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid       /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    server_tokens off;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    map $http_user_agent $loggable {
+        ~ELB-HealthChecker  0;
+        default             1;
+    }
+
+    access_log  /var/log/nginx/access.log  main if=$loggable;
+
+    sendfile        on;
+    tcp_nopush      on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_types text/css application/javascript application/json;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
# チケットへのリンク
https://bit.ly/3juvLBm

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
Nginxのログを出力しない設定を追加
技術のバージョンを非表示にする。（セキュリティ対策）

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
ALBからの定期的なログがcloud watch logsに表示されるから。（問題の特定がむずかしくなる）

## やったこと
・やったことを簡単にまとめる
省略

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと
`nginx.conf`：nginxの設定ファイル
https://hack-le.com/nginx/


## 今後の変更計画


## 備考
・その他伝えたいこと