### PR TITLE
https通信の設定を追加

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\RedirectToHttps::class,
     ];
 
     /**

--- a/backend/app/Http/Middleware/RedirectToHttps.php
+++ b/backend/app/Http/Middleware/RedirectToHttps.php
@@ -23,25 +23,25 @@ class RedirectToHttps
 
     public function is_ssl()
     {
-        if ( isset($_SERVER['HTTPS']) === true ) // Apache
+        if (isset($_SERVER['HTTPS']) === true ) // Apache
         {
-            return ( $_SERVER['HTTPS'] === 'on' or $_SERVER['HTTPS'] === '1' );
+            return ($_SERVER['HTTPS'] === 'on' or $_SERVER['HTTPS'] === '1');
         }
-        elseif ( isset($_SERVER['SSL']) === true ) // IIS
+        elseif (isset($_SERVER['SSL']) === true) // IIS
         {
-            return ( $_SERVER['SSL'] === 'on' );
+            return ($_SERVER['SSL'] === 'on');
         }
-        elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) === true ) // Reverse proxy
+        elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) === true) // Reverse proxy
         {
-            return ( strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https' );
+            return (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https');
         }
-        elseif ( isset($_SERVER['HTTP_X_FORWARDED_PORT']) === true ) // Reverse proxy
+        elseif (isset($_SERVER['HTTP_X_FORWARDED_PORT']) === true) // Reverse proxy
         {
-            return ( $_SERVER['HTTP_X_FORWARDED_PORT'] === '443' );
+            return ($_SERVER['HTTP_X_FORWARDED_PORT'] === '443');
         }
-        elseif ( isset($_SERVER['SERVER_PORT']) === true )
+        elseif (isset($_SERVER['SERVER_PORT']) === true)
         {
-            return ( $_SERVER['SERVER_PORT'] === '443' );
+            return ($_SERVER['SERVER_PORT'] === '443');
         }
 
         return false;

--- a/backend/app/Http/Middleware/RedirectToHttps.php
+++ b/backend/app/Http/Middleware/RedirectToHttps.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class RedirectToHttps
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if(!$this->is_ssl() && config('app.env') === 'production') {
+            return redirect('https://'.$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']);
+        }
+        return $next($request);
+    }
+
+    public function is_ssl()
+    {
+        if ( isset($_SERVER['HTTPS']) === true ) // Apache
+        {
+            return ( $_SERVER['HTTPS'] === 'on' or $_SERVER['HTTPS'] === '1' );
+        }
+        elseif ( isset($_SERVER['SSL']) === true ) // IIS
+        {
+            return ( $_SERVER['SSL'] === 'on' );
+        }
+        elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) === true ) // Reverse proxy
+        {
+            return ( strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https' );
+        }
+        elseif ( isset($_SERVER['HTTP_X_FORWARDED_PORT']) === true ) // Reverse proxy
+        {
+            return ( $_SERVER['HTTP_X_FORWARDED_PORT'] === '443' );
+        }
+        elseif ( isset($_SERVER['SERVER_PORT']) === true )
+        {
+            return ( $_SERVER['SERVER_PORT'] === '443' );
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Http/Middleware/TrustProxies.php
+++ b/backend/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies = "*";
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -18,5 +18,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (env('APP_ENV') === 'production') {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
# チケットへのリンク
URLを追加

## 問題
SSL証明書は有効だが、https通信にならない。

## 変更の概要
・変更の概要 \
・関連するIssueやプルリクエスト
AWS内ではhttps通信はできてる（？）ものの、クライアントサイドからWebサーバーはhttps通信になってない？
と仮定して、httpsの設定を追加してみた。

## なぜこの変更をするのか
・変更をする理由 \
※前提知識がなくても分かるようにすること
https通信させるため。

## やったこと
・やったことを簡単にまとめる
httpsにredirectするclassを追加
本番環境において、httpに接続された場合は全てhttpsにredirectする
公式Docにならって一部シングルクオートに変更（意図しないバグの予防）
→IPアドレス

## 影響範囲
・ユーザに影響すること \
・システムに影響すること

## 学習したこと
・Inputしたこと \
・悩んだこと

## 今後の変更計画



## 備考
・その他伝えたいこと